### PR TITLE
connect to leader.mesos in HA deployments

### DIFF
--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -19,7 +19,7 @@
     <org.jenkinsci.plugins.mesos.MesosCloud plugin="mesos">
       <name>MesosCloud</name>
       <nativeLibraryPath>/opt/mesosphere/lib/libmesos.so</nativeLibraryPath>
-      <master>master.mesos:5050</master>
+      <master>leader.mesos:5050</master>
       <description></description>
       <frameworkName>jenkins</frameworkName>
       <slavesUser>root</slavesUser>


### PR DESCRIPTION
Prior to this commit, Jenkins connected to `master.mesos:5050` which is
fine for single-master deployments. When you're running Mesos in a HA
deployment (3 or 5 masters), this could result in Jenkins attempting to
register with a non-leader. Jenkins will work fine, but the framework
won't be registered to the cluster, and it won't appear in the Mesos UI.

This commit modifies the master hostname/IP address from
`master.mesos:5050` to `leader.mesos:5050`. If the leader should change,
Mesos-DNS will update this record, and Jenkins will connect to the
current leader.