### PR TITLE
use the java:openjdk-8-jdk image by default

### DIFF
--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -41,7 +41,7 @@
           <jnlpArgs></jnlpArgs>
           <containerInfo>
             <type>DOCKER</type>
-            <dockerImage>java:openjdk-8-jre</dockerImage>
+            <dockerImage>java:openjdk-8-jdk</dockerImage>
             <networking>BRIDGE</networking>
             <useCustomDockerCommandShell>false</useCustomDockerCommandShell>
             <customDockerCommandShell />


### PR DESCRIPTION
Prior to this commit, we used the openjdk-8-jre image by default, which
didn't include Git. The JDK image includes Git.