### PR TITLE
install the ansicolor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Base packages:
   * [Jenkins][jenkins-home] 1.625.3 (LTS)
 
 Jenkins plugins:
+  * [ansicolor][ansicolor-plugin] v0.4.2
   * [credentials][credentials-plugin] v1.23
   * [git][git-plugin] v2.4.0
   * [git-client][git-client-plugin] v1.19.0
@@ -42,6 +43,7 @@ To install Jenkins for the DCOS, perform the following steps.
 
 Jenkins should now be available at <http://dcos-master/service/jenkins>
 
+[ansicolor-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/AnsiColor+Plugin
 [credentials-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
 [git-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
 [git-client-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin

--- a/scripts/plugin_install.sh
+++ b/scripts/plugin_install.sh
@@ -13,6 +13,7 @@ JENKINS_PLUGINS_MIRROR="https://updates.jenkins-ci.org/download/plugins"
 
 # Jenkins plugins are specified here, following the format "pluginname/version"
 JENKINS_PLUGINS=(
+    "ansicolor/0.4.2"
     "credentials/1.23"
     "git/2.4.0"
     "git-client/1.19.0"


### PR DESCRIPTION
The AnsiColor plugin adds support for ANSI escape sequences, most
notably color, to the Console Output for a particular build. This should
improve the readability and user experience when viewing console logs
via the Jenkins web UI, but won't affect the "plain text" console logs.