### PR TITLE
Populate SSH known_hosts file

### DIFF
--- a/dind-agent/Dockerfile
+++ b/dind-agent/Dockerfile
@@ -1,8 +1,12 @@
 FROM docker:1.9-dind
-RUN apk --update add openjdk7-jre unzip git python python3 bash jq
+RUN apk --update add openjdk7-jre unzip git python python3 bash jq openssh-client
 
 COPY wrapper.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/wrapper.sh
+
+# Add any SSH known hosts to the environment variable $SSH_KNOWN_HOSTS
+ENV SSH_KNOWN_HOSTS github.com
+RUN ssh-keyscan $SSH_KNOWN_HOSTS | tee /etc/ssh/ssh_known_hosts
 
 ENTRYPOINT []
 CMD []


### PR DESCRIPTION
This PR introduces the ability to add the public keys for known SSH hosts.
* On the Jenkins master, this is accomplished by passing a space-separated string of hosts using the environment variable `SSH_KNOWN_HOSTS`. `ssh-keyscan` will gather the public keys for each of these hosts and write them to `/etc/ssh/ssh_known_hosts`.
* On our default dind-agent Docker image for Jenkins build agents, I've added github.com specifically to the Dockerfile. Users not using GitHub should either add additional well-known hosts to this list, or adapt this Docker image to their organization's needs.