### PR TITLE
Improve code readability for bootstrap.py

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -19,10 +19,7 @@ def is_firstrun(jenkins_home_dir):
     :param jenkins_home_dir: the path to $JENKINS_HOME on disk
     :return: boolean; True if $JENKINS_HOME isn't populated, false otherwise
     """
-    if len(os.listdir(jenkins_home_dir)) == 0:
-        return True
-    else:
-        return False
+    return len(os.listdir(jenkins_home_dir)) == 0
 
 
 def populate_jenkins_config_xml(config_xml, master, name, host, port):
@@ -113,8 +110,6 @@ def populate_known_hosts(hosts, dest_file):
 
 
 def main():
-    firstrun = True
-
     try:
         jenkins_staging_dir = os.environ['JENKINS_STAGING']
         jenkins_home_dir = os.environ['JENKINS_HOME']
@@ -137,11 +132,8 @@ def main():
     # volume. If data exists in that directory (e.g. Marathon has restarted
     # a Jenkins master task), then we'll make changes in-place to the existing
     # data without overwriting anything the user already has.
-    if is_firstrun(jenkins_home_dir):
-        jenkins_data_dir = jenkins_staging_dir
-    else:
-        firstrun = False
-        jenkins_data_dir = jenkins_home_dir
+    firstrun = is_firstrun(jenkins_home_dir)
+    jenkins_data_dir = jenkins_staging_dir if firstrun else jenkins_home_dir
 
     populate_jenkins_config_xml(
         os.path.join(jenkins_data_dir, 'config.xml'),


### PR DESCRIPTION
This commit removes the if-statement from `is_firstrun` and allows the
comparison to return directly.  main() now sets "firstrun" to the result
of "is_firstrun()", instead of a hard coded value of `True`, and sets
"jenkins_data_dir" accordingly.