### PR TITLE
default jenkins agent should use -noReconnect

### DIFF
--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -38,7 +38,7 @@
           <remoteFSRoot>jenkins</remoteFSRoot>
           <idleTerminationMinutes>3</idleTerminationMinutes>
           <jvmArgs>-Xms16m -XX:+UseConcMarkSweepGC -Djava.net.preferIPv4Stack=true</jvmArgs>
-          <jnlpArgs></jnlpArgs>
+          <jnlpArgs>-noReconnect</jnlpArgs>
           <containerInfo>
             <type>DOCKER</type>
             <dockerImage>mesosphere/jenkins-dind:0.2.0</dockerImage>


### PR DESCRIPTION
We ran into an issue where one of our DCOS agents was having trouble
communicating with the agent that the Jenkins scheduler was running on.
Because of the default reconnect behavior in Jenkins' slave.jar, this
meant that the Jenkins agent came up fine as a Mesos task, and got stuck
in an infinite loop attempting to connect to the Jenkins scheduler every
10 seconds.

This commit modifies the behavior of slave.jar to never attempt to
reconnect with a master on network failure. Not only will this prevent
any infinite loops from network issues, it will also ensure that if the
scheduler fails over and starts running with a different host/port
combination, that any running tasks will exit on their own instead of
running indefinitely.