### PR TITLE
use overlay storage driver instead of vfs

### DIFF
--- a/dind-agent/wrapper.sh
+++ b/dind-agent/wrapper.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "==> Launching the Docker daemon..."
-dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=vfs &
+dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=overlay &
 
 while(! docker info > /dev/null 2>&1); do
     echo "==> Waiting for the Docker daemon to come online..."


### PR DESCRIPTION
The docker engine that this image is running on in my system is using the overlay storage driver, and I noticed if I also use that driver performance is drastically improved.

I'm not sure what driver will be used if that option is removed completely, but it might be worth investigating.