### PR TITLE
Update documentation for jenkins-dind

### DIFF
--- a/dind-agent/README.md
+++ b/dind-agent/README.md
@@ -4,6 +4,9 @@ own Docker daemon. This is useful if you're trying to run Jenkins agents on a
 Mesos cluster, and you also want to build and push Docker images using your
 CI system.
 
+For full documentation on how to use this Docker image, please refer to
+<http://mesosphere.github.io/jenkins-mesos/docs/builds.html>.
+
 ## Usage
 ### Command line
 Try it out locally by running the following command:

--- a/docs/docs/builds.md
+++ b/docs/docs/builds.md
@@ -19,6 +19,29 @@ This image includes many tools by default ([Dockerfile](https://github.com/mesos
 
 However, in many cases, you will have your own dependencies to specify for your build. You can do these by providing unique container images for each type of build. The instructions below specify how you can do this.
 
+## A note on storage drivers
+
+In the jenkins-dind image, we deliberately chose to use VFS for the storage
+driver. With true Docker-in-Docker (e.g. not bind-mounting the socket from the
+host), VFS is the absolute safest option for a backend because it doesn't use
+Docker's copy-on-write system. While this makes it slower than other options,
+it avoids problems between the parent container's filesystem and the child
+container's copy-on-write system. For more info, see the "Docker-in-Docker: the
+ugly" section from Jerome's post:
+<https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/>
+
+Although slower than other systems, this approach should work for all of our
+users out of the box. As always, you should feel free to (and should!) create
+custom Jenkins build agent Docker images and substitute them out for our
+default jenkins-dind image in the Jenkins master's configuration. But
+otherwise, We think our current configuration (using VFS) should be the default
+for this project, even if that means we take a performance hit, at least for
+the time being.
+
+At least one community member has had success using the OverlayFS driver with
+their Jenkins infrastructure. For more information, please refer to the
+following GitHub issue: <https://github.com/mesosphere/jenkins-mesos/issues/55>.
+
 # Creating Custom Agent Containers
 
 The recommended approach to providing your own dependencies is to extend the provided `jenkins-dind-agent` image and install the packages you require.

--- a/docs/docs/builds.md
+++ b/docs/docs/builds.md
@@ -4,20 +4,30 @@ title: Configuring Builds
 
 # Configuring Builds
 
-DCOS runs everything inside Docker by default. This is to minimise dependencies on the underlying host operating system and to allow for maximum resilience in the case of a host failing.
+DCOS runs everything inside Docker by default. This is to minimise dependencies
+on the underlying host operating system and to allow for maximum resilience in
+the case of a host failing.
 
-When using Jenkins on DCOS, the Mesos scheduler creates new Jenkins slaves that run as Mesos tasks within a Docker container. Builds that the user configures are then run inside the same container. Since many builds typically involve steps that invoke the Docker utility, e.g. `docker build` or `docker push`, we provide a `mesosphere/jenkins-dind` Docker image and configure the Mesos plugin to use this by default.
+When using Jenkins on DCOS, the Mesos scheduler creates new Jenkins slaves that
+run as Mesos tasks within a Docker container. Builds that the user configures
+are then run inside the same container. Since many builds typically involve
+steps that invoke the Docker utility, e.g. `docker build` or `docker push`, we
+provide a `mesosphere/jenkins-dind` Docker image and configure the Mesos plugin
+to use this by default.
 
-This image includes many tools by default ([Dockerfile](https://github.com/mesosphere/jenkins-mesos/blob/master/dind-agent/Dockerfile)):
+This image includes many tools by default
+([Dockerfile](https://github.com/mesosphere/jenkins-mesos/blob/master/dind-agent/Dockerfile)):
 
-* OpenJDK 7
-* Python 2
-* Python 3
-* Bash
-* Git
-* ssh
+    * OpenJDK 7
+    * Python 2
+    * Python 3
+    * Bash
+    * Git
+    * ssh
 
-However, in many cases, you will have your own dependencies to specify for your build. You can do these by providing unique container images for each type of build. The instructions below specify how you can do this.
+However, in many cases, you will have your own dependencies to specify for your
+build. You can do these by providing unique container images for each type of
+build. The instructions below specify how you can do this.
 
 ## A note on storage drivers
 
@@ -44,9 +54,12 @@ following GitHub issue: <https://github.com/mesosphere/jenkins-mesos/issues/55>.
 
 # Creating Custom Agent Containers
 
-The recommended approach to providing your own dependencies is to extend the provided `jenkins-dind-agent` image and install the packages you require.
+The recommended approach to providing your own dependencies is to extend the
+provided `jenkins-dind-agent` image and install the packages you require.
 
-The example below shows how you could create an image which includes `sbt`, a Scala build tool (the following code snippet is based on [docker-sbt](https://github.com/1science/docker-sbt/blob/latest/Dockerfile)):
+The example below shows how you could create an image which includes `sbt`, a
+Scala build tool (the following code snippet is based on
+[docker-sbt](https://github.com/1science/docker-sbt/blob/latest/Dockerfile)):
 
 ```sh
 FROM mesosphere/jenkins-dind:0.2.0
@@ -61,34 +74,46 @@ RUN curl -sL "http://dl.bintray.com/sbt/native-packages/sbt/$SBT_VERSION/sbt-$SB
 
 ## Configuring SSH Host Keys (optional)
 
-If you aren't using GitHub to host your git repositories and wish to use ssh to clone your git repositories, you will need to add your git server's host keys to `/etc/ssh/ssh_known_hosts`. 
+If you aren't using GitHub to host your git repositories and wish to use ssh to
+clone your git repositories, you will need to add your git server's host keys
+to `/etc/ssh/ssh_known_hosts`. 
 
-Adding the following lines to your Dockerfile will add your keys, replacing `my.git.server` with the actual hostname:
+Adding the following lines to your Dockerfile will add your keys, replacing
+`my.git.server` with the actual hostname:
 
 ```sh
 ENV SSH_KNOWN_HOSTS github.com my.git.server
 RUN ssh-keyscan $SSH_KNOWN_HOSTS | tee /etc/ssh/ssh_known_hosts
 ```
 
-This is necessary because strict host key checking is on by default and clones over ssh will fail if your host keys aren't explicitly added.
+This is necessary because strict host key checking is on by default and clones
+over ssh will fail if your host keys aren't explicitly added.
 
 ## Pushing
 
-Once built, you can then push this to DockerHub or your own private Docker registry. This registry must be accessible by DCOS agents.
+Once built, you can then push this to DockerHub or your own private Docker
+registry. This registry must be accessible by DCOS agents.
 
 ## Configuring Jenkins
 
-To make this image available to builds in Jenkins, you need to add it manually via the "Manage Jenkins" -> "Configure Jenkins" page.
+To make this image available to builds in Jenkins, you need to add it manually
+via the "Manage Jenkins" -> "Configure Jenkins" page.
 
-Scroll to the "Cloud" section at the bottom and press "Advanced". You will see a grey button to "Add Slave Info":
+Scroll to the "Cloud" section at the bottom and press "Advanced". You will see
+a grey button to "Add Slave Info":
 
 ![Add Slave Info]({{site.baseurl}}/img/add-slave-info.png)
 
-Most of the defaults are sufficient here but you may wish to change the "Label String" to something that reflects the contents of this custom build file. In this case, we'll set the label string to `sbt`:
+Most of the defaults are sufficient here but you may wish to change the "Label
+String" to something that reflects the contents of this custom build file. In
+this case, we'll set the label string to `sbt`:
 
 ![sbt Label String]({{site.baseurl}}/img/sbt-label-string.png)
 
-To set up the new image, press "Advanced" again and select the "Use Docker Containerizer" checkbox. Here you can specify the Docker Image name. Be sure to select "Docker Privileged Mode" and to specify a custom Docker command shell of `wrapper.sh`:
+To set up the new image, press "Advanced" again and select the "Use Docker
+Containerizer" checkbox. Here you can specify the Docker Image name. Be sure to
+select "Docker Privileged Mode" and to specify a custom Docker command shell of
+`wrapper.sh`:
 
 ![Docker Containerizer Settings]({{site.baseurl}}/img/docker-containerizer-settings.png)
 
@@ -96,7 +121,9 @@ Don't forget to hit Save!
 
 ## Configuring Your Build
 
-Finally, to configure a build to use the newly specified image, click on "Configure" for the build, select "Restrict where this project can be run" and specify the same "Label String":
+Finally, to configure a build to use the newly specified image, click on
+"Configure" for the build, select "Restrict where this project can be run" and
+specify the same "Label String":
 
 ![Build Label String Configuration]({{site.baseurl}}/img/build-label-string.png)
 


### PR DESCRIPTION
This PR updates documentation for the jenkins-dind Docker image that we include in this repository. Specifically, it provides justification for using VFS, despite it (probably) being the slowest storage driver for Docker.

Also, this PR reformats the builds.md documentation for each line to be 80 characters long, for ease of maintenance going forward.