### PR TITLE
Update Mesos plugin version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Jenkins plugins:
   * [job-dsl][job-dsl-plugin] v1.42
   * [jobConfigHistory][jobConfigHistory-plugin] v2.12
   * [jquery][jquery] v1.7.2-1
-  * [mesos][mesos-plugin] v0.10.0
+  * [mesos][mesos-plugin] v0.11.0
   * [monitoring][monitoring-plugin] v1.58.0
   * [parameterized-trigger][parameterized-trigger-plugin] v2.30
   * [plain-credentials][plain-credentials] v1.1

--- a/scripts/plugin_install.sh
+++ b/scripts/plugin_install.sh
@@ -25,7 +25,7 @@ JENKINS_PLUGINS=(
     "jquery/1.7.2-1"
     "job-dsl/1.42"
     "jobConfigHistory/2.12"
-    "mesos/0.10.0"
+    "mesos/0.11.0"
     "monitoring/1.58.0"
     "parameterized-trigger/2.30"
     "plain-credentials/1.1"


### PR DESCRIPTION
This new version includes a number of fixes, including support for Mesos 0.27.0: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkins-mesos/A_5JuE9eP0k/tnF9ey1IIAAJ

To be merged only once the Mesos plugin is available from the Jenkins Update Center: https://wiki.jenkins-ci.org/display/JENKINS/Mesos+Plugin
