### PR TITLE
[do not merge] ability to customize docker storage driver

### DIFF
--- a/dind-agent/wrapper.sh
+++ b/dind-agent/wrapper.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 set -e
 
-echo "==> Launching the Docker daemon..."
-dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=overlay &
+# If the first argument to this script is "--storage-driver=foo", then set
+# the variable $DOCKER_STORAGE_DRIVER to the passed in argument. Otherwise,
+# default to the "overlay" storage driver.
+if [[ "$1" =~ "--storage-driver" ]]; then
+    DOCKER_STORAGE_DRIVER="${1#*=}"
+    shift
+else
+    DOCKER_STORAGE_DRIVER="overlay"
+fi
+
+echo "==> Launching the Docker daemon with storage driver '${DOCKER_STORAGE_DRIVER}' ..."
+dind docker daemon --host=unix:///var/run/docker.sock --storage-driver=${DOCKER_STORAGE_DRIVER} &
 
 while(! docker info > /dev/null 2>&1); do
     echo "==> Waiting for the Docker daemon to come online..."


### PR DESCRIPTION
Prior to this commit, we hard-coded the Docker storage driver in
wrapper.sh. After further testing, it appears that the 'overlay' storage
driver can be used instead of 'vfs', allowing for improved performance.

This commit further allows a user to customize the Docker storage driver
by setting the `$DOCKER_STORAGE_DRIVER` environment variable. If it
isn't set, it will default to `overlay` per gh-56.