### PR TITLE
jenkins-mesos 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changes
+## v0.2.2 (2016-03-10)
+  * DinD image now uses the `overlay` storage driver instead of `vfs`, which
+  results in a (roughly) 10x performance and storage improvement. This was
+  tested on both CoreOS and CentOS 7.1 with the default Docker configuration.
+  * Update Mesos plugin to v0.11.0
+  * Add GitHub plugin
+  * Misc fixes and documentation updates
+
+## v0.2.1 (2016-02-28)
+  * Jenkins agents created by the Mesos plugins will no longer attempt to
+  reconnect when they fail to connect to the master
+  * Update Mesos plugin version to 0.10.0
+  * Add the credentials binding plugin, and several dependencies
+  * Add the build pipeline plugin
+  * Add the jQuery plugin
+  * Update DinD base image to 1.10
+  * Update JRE 7 to JDK 8 in the dind-agent image, and add the ca-certificates
+  package
+  * Install perl in the dind-agent image, which is required for some Git
+  operations
+  * Documentation updates and other misc fixes
+
+## v0.2.0 (2016-02-05)
+  * Update Jenkins to 1.642.1
+  * Update various plugins to the latest versions
+  * Add jobConfigHistory plugin to Jenkins
+  * Check for plugin updates when building the Docker image
+  * Support for third-party Git servers (populating the SSH known hosts file)
+  * Maintain the Mesos master URL in bootstrap.py
+  * Swap Tomcat for Nginx to improve URL rewriting when accessing Jenkins
+  through Admin Router
+  * Rewrote Git history, removing old binaries over 1M, to improve future
+  development experience
+  * Other misc fixes
+
+## v0.1.5 (2016-01-19)
+  * Add a Jenkins Docker-in-Docker (dind) agent image to the repo, for building
+    Docker containers when running on top of DCOS.
+
+## v0.1.4 (2016-01-19)
+  * Remove the labelString configuration entirely
+  * Remove a mention of the Mesosphere Multiverse repo in the docs
+
+## v0.1.3 (2016-01-11)
+  * Update Jenkins to 1.625.3
+  * Update the Jenkins Mesos plugin to v0.9.0
+  * Update the Tomcat version to v8.0.30
+  * Add the ansicolor plugin to Jenkins
+  * Switch to the `java:openjdk-8-jdk` image, which includes build dependencies
+    such as Git
+  * Use ZooKeeper for Mesos master resolution
+  * Update the included Jenkins agent label expression
+
+## v0.1.2 (2015-12-02)
+  * Connect to `leader.mesos` instead of `master.mesos` in HA deployments
+
+## v0.1.1 (2015-11-17)
+  * Include Jenkins 1.625.2, which includes security updates
+  * Add some basic docs
+
+## v0.1.0 (2015-10-22)
+Initial release

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Build Status](https://teamcity.mesosphere.io/guestAuth/app/rest/builds/buildType:(id:Oss_Jenkins_PublishDevelopmentDocker)/statusIcon)](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Jenkins_PublishDevelopmentDocker&guest=1)
 [![Docker Stars](https://img.shields.io/docker/stars/mesosphere/jenkins.svg)][docker-hub]
 [![Docker Pulls](https://img.shields.io/docker/pulls/mesosphere/jenkins.svg)][docker-hub]
-[![Image Size](https://img.shields.io/imagelayers/image-size/mesosphere/jenkins/0.2.1.svg)](https://imagelayers.io/?images=mesosphere/jenkins:0.2.1)
-[![Image Layers](https://img.shields.io/imagelayers/layers/mesosphere/jenkins/0.2.1.svg)](https://imagelayers.io/?images=mesosphere/jenkins:0.2.1)
+[![Image Size](https://img.shields.io/imagelayers/image-size/mesosphere/jenkins/0.2.2.svg)](https://imagelayers.io/?images=mesosphere/jenkins:0.2.2)
+[![Image Layers](https://img.shields.io/imagelayers/layers/mesosphere/jenkins/0.2.2.svg)](https://imagelayers.io/?images=mesosphere/jenkins:0.2.2)
 
 Run a Jenkins master on Mesos and Marathon, using Docker and Nginx.
 

--- a/conf/jenkins/config.xml
+++ b/conf/jenkins/config.xml
@@ -41,7 +41,7 @@
           <jnlpArgs>-noReconnect</jnlpArgs>
           <containerInfo>
             <type>DOCKER</type>
-            <dockerImage>mesosphere/jenkins-dind:0.2.1</dockerImage>
+            <dockerImage>mesosphere/jenkins-dind:0.2.2</dockerImage>
             <networking>BRIDGE</networking>
             <useCustomDockerCommandShell>true</useCustomDockerCommandShell>
             <customDockerCommandShell>wrapper.sh</customDockerCommandShell>

--- a/dind-agent/README.md
+++ b/dind-agent/README.md
@@ -1,8 +1,8 @@
 # Jenkins Docker-in-Docker Agent
 [![Docker Stars](https://img.shields.io/docker/stars/mesosphere/jenkins-dind.svg)][docker-hub]
 [![Docker Pulls](https://img.shields.io/docker/pulls/mesosphere/jenkins-dind.svg)][docker-hub]
-[![Image Size](https://img.shields.io/imagelayers/image-size/mesosphere/jenkins-dind/0.2.1.svg)](https://imagelayers.io/?images=mesosphere/jenkins-dind:0.2.1)
-[![Image Layers](https://img.shields.io/imagelayers/layers/mesosphere/jenkins-dind/0.2.1.svg)](https://imagelayers.io/?images=mesosphere/jenkins-dind:0.2.1)
+[![Image Size](https://img.shields.io/imagelayers/image-size/mesosphere/jenkins-dind/0.2.2.svg)](https://imagelayers.io/?images=mesosphere/jenkins-dind:0.2.2)
+[![Image Layers](https://img.shields.io/imagelayers/layers/mesosphere/jenkins-dind/0.2.2.svg)](https://imagelayers.io/?images=mesosphere/jenkins-dind:0.2.2)
 
 A simple Docker image for running a Jenkins agent alongside its very
 own Docker daemon. This is useful if you're trying to run Jenkins agents on a


### PR DESCRIPTION
Prepare for the 0.2.2 release of jenkins-mesos, including changes to the dind-agent image and adding a changelog to the repo.