### PR TITLE
add github-api plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Jenkins plugins:
   * [git][git-plugin] v2.4.1
   * [git-client][git-client-plugin] v1.19.2
   * [github][github-plugin] v1.17.1
+  * [github-api][github-api-plugin] v1.72.1
   * [greenballs][greenballs-plugin] v1.15
   * [job-dsl][job-dsl-plugin] v1.42
   * [jobConfigHistory][jobConfigHistory-plugin] v2.12
@@ -76,6 +77,7 @@ To release a new version of this package:
 [git-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
 [git-client-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Git+Client+Plugin
 [github-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Plugin
+[github-api-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/GitHub+API+Plugin
 [greenballs-plugin]: https://wiki.jenkins-ci.org/display/JENKINS/Green+Balls
 [jenkins-conf]: /conf/jenkins/config.xml
 [jenkins-dind]: /dind-agent/README.md

--- a/scripts/plugin_install.sh
+++ b/scripts/plugin_install.sh
@@ -21,6 +21,7 @@ JENKINS_PLUGINS=(
     "git/2.4.1"
     "git-client/1.19.2"
     "github/1.17.1"
+    "github-api/1.72.1"
     "greenballs/1.15"
     "jquery/1.7.2-1"
     "job-dsl/1.42"


### PR DESCRIPTION
The GitHub plugin depends on the github-api plugin, but prior to this
commit it wasn't installed. This commit adds the github-api plugin so
that Jenkins can successfully load the GitHub plugin.