### PR TITLE
The `requests` library is no longer a requirement

### DIFF
--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -1,2 +1,1 @@
 shakedown
-requests


### PR DESCRIPTION
Shakedown provides a `http` object which overlays DC/OS authentication
on top of the `requests` library.